### PR TITLE
fix: ensure schema-aware inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,18 +140,27 @@ console.log(containers); // ['users', 'products', ...]
 #### Insert
 
 ```typescript
-// Single insert
+// Object-based insert (property order doesn't matter)
 await griddb.insert({
   containerName: 'users',
-  data: { id: 1, name: 'Alice', email: 'alice@example.com' }
+  data: { name: 'Alice', email: 'alice@example.com', id: 1 }
 });
 
-// Multiple insert
+// Multiple insert with objects
 await griddb.insert({
   containerName: 'users',
   data: [
-    { id: 2, name: 'Bob', email: 'bob@example.com' },
-    { id: 3, name: 'Charlie', email: 'charlie@example.com' }
+    { name: 'Bob', email: 'bob@example.com', id: 2 },
+    { name: 'Charlie', email: 'charlie@example.com', id: 3 }
+  ]
+});
+
+// Mixed object and array data
+await griddb.insert({
+  containerName: 'users',
+  data: [
+    { name: 'Dave', email: 'dave@example.com', id: 4 },
+    [5, 'Eve', 'eve@example.com'] // Arrays must follow column order
   ]
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,6 +123,7 @@ export interface InsertOptions<T = any> {
   containerName: string;
   data: T | T[];
   updateIfExists?: boolean;
+  schema?: GridDBColumn[];
 }
 
 export interface UpdateOptions<T = any> {

--- a/src/utils/transformers.ts
+++ b/src/utils/transformers.ts
@@ -2,22 +2,37 @@
  * Data transformation utilities for GridDB
  */
 
-import { GridDBRow, GridDBValue, SelectOptions, GridDBQuery } from '../types';
+import {
+  GridDBRow,
+  GridDBValue,
+  SelectOptions,
+  GridDBQuery,
+  GridDBColumn
+} from '../types';
 
 /**
  * Transform object row to array format for GridDB
  */
-export function transformRowToArray(row: any): any[] {
+export function transformRowToArray(
+  row: any,
+  containerSchema?: GridDBColumn[]
+): any[] {
   if (!row) {
     return [];
   }
-  
+
   if (Array.isArray(row)) {
     return row;
   }
-  
-  // If object, convert to array based on property order
-  return Object.values(row);
+
+  if (containerSchema && containerSchema.length > 0) {
+    return containerSchema.map(column => toGridDBValue(row[column.name]));
+  }
+
+  console.warn(
+    'GridDB Client: No schema provided for transformRowToArray. Column order may be incorrect.'
+  );
+  return Object.values(row).map(toGridDBValue);
 }
 
 /**

--- a/tests/error-handling.test.ts
+++ b/tests/error-handling.test.ts
@@ -233,7 +233,13 @@ describe('Error Handling', () => {
   describe('Edge Cases', () => {
     it('should handle very large batch sizes', async () => {
       const mockClient = {
-        request: vi.fn().mockResolvedValue({ success: true })
+        request: vi.fn().mockResolvedValue({ success: true }),
+        getContainerInfo: vi.fn().mockResolvedValue({
+          container_name: 'test',
+          container_type: 'COLLECTION',
+          rowkey: true,
+          columns: [{ name: 'id', type: 'INTEGER' as const }]
+        })
       };
       const crud = new CRUDOperations(mockClient as any);
 

--- a/tests/utils/transformers.test.ts
+++ b/tests/utils/transformers.test.ts
@@ -15,7 +15,7 @@ describe('Transformers', () => {
     it('should transform object to array', () => {
       const row = { id: 1, name: 'John', age: 30 };
       const result = transformRowToArray(row);
-      
+
       expect(result).toEqual([1, 'John', 30]);
     });
 
@@ -29,8 +29,21 @@ describe('Transformers', () => {
     it('should handle empty object', () => {
       const row = {};
       const result = transformRowToArray(row);
-      
+
       expect(result).toEqual([]);
+    });
+
+    it('should use schema to ensure column order', () => {
+      const row = { name: 'John', age: 30, id: 1 };
+      const schema = [
+        { name: 'id', type: 'INTEGER' as const },
+        { name: 'name', type: 'STRING' as const },
+        { name: 'age', type: 'INTEGER' as const }
+      ];
+
+      const result = transformRowToArray(row, schema);
+
+      expect(result).toEqual([1, 'John', 30]);
     });
   });
 


### PR DESCRIPTION
## Summary
- align row insertion with container schema order by leveraging schema-aware `transformRowToArray`
- fetch and cache container schema in CRUD operations and support optional `schema` in insert options
- document and test object-based inserts regardless of property order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae713ef6cc832aa42bb19eb0d8462e