### PR TITLE
fix: use correct DML endpoint for DELETE/UPDATE on GridDB Cloud

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,10 @@ export class GridDB {
     return this.crud.executeSql(stmt, bindings);
   }
 
+  async executeDml(stmt: string, bindings?: any[]): Promise<any> {
+    return this.crud.executeDml(stmt, bindings);
+  }
+
   async executeTql(containerName: string, query: string): Promise<any[]> {
     return this.crud.executeTql(containerName, query);
   }

--- a/src/operations/crud.ts
+++ b/src/operations/crud.ts
@@ -120,7 +120,7 @@ export class CRUDOperations {
    */
   async update<T = GridDBRow>(options: UpdateOptions<T>): Promise<void> {
     const { containerName, data, where, bindings } = options;
-    
+
     if (!where) {
       // If no where clause, update by rowkey (first column)
       await this.insert({
@@ -129,15 +129,15 @@ export class CRUDOperations {
         updateIfExists: true
       });
     } else {
-      // Use SQL UPDATE statement
+      // Use SQL UPDATE statement via DML endpoint
       const columns = Object.keys(data as any);
       const setClause = columns.map(col => `${col} = ?`).join(', ');
       const values = columns.map(col => (data as any)[col]);
-      
+
       const stmt = `UPDATE ${containerName} SET ${setClause} WHERE ${where}`;
       const allBindings = [...values, ...(bindings || [])];
-      
-      await this.executeSql(stmt, allBindings);
+
+      await this.executeDml(stmt, allBindings);
     }
   }
 
@@ -146,9 +146,9 @@ export class CRUDOperations {
    */
   async delete(options: DeleteOptions): Promise<void> {
     const { containerName, where, bindings } = options;
-    
+
     const stmt = `DELETE FROM ${containerName} WHERE ${where}`;
-    await this.executeSql(stmt, bindings);
+    await this.executeDml(stmt, bindings);
   }
 
   /**
@@ -188,26 +188,57 @@ export class CRUDOperations {
   }
 
   /**
-   * Execute raw SQL query
+   * Execute raw SQL SELECT query
    */
   async executeSql(stmt: string, bindings?: any[]): Promise<QueryResult> {
     const query: GridDBQuery = {
       type: 'sql-select',
       stmt,
-      bindings
     };
 
+    // Only include bindings if provided and non-empty
+    // GridDB Cloud Web API rejects requests with undefined/empty bindings
+    if (bindings && bindings.length > 0) {
+      query.bindings = bindings;
+    }
+
     const response = await this.client.post('/sql/dml/query', [query]);
-    
+
     // Handle response format
     if (Array.isArray(response) && response.length > 0) {
       return response[0];
     }
-    
+
     return {
       columns: [],
       results: []
     };
+  }
+
+  /**
+   * Execute SQL DML statement (INSERT, UPDATE, DELETE)
+   * Uses the /sql/update endpoint with type 'sql-update'
+   * which is required by GridDB Cloud Web API for DML operations
+   */
+  async executeDml(stmt: string, bindings?: any[]): Promise<any> {
+    const query: GridDBQuery = {
+      type: 'sql-update',
+      stmt,
+    };
+
+    // Only include bindings if provided and non-empty
+    if (bindings && bindings.length > 0) {
+      query.bindings = bindings;
+    }
+
+    const response = await this.client.post('/sql/update', [query]);
+
+    // Handle response format
+    if (Array.isArray(response) && response.length > 0) {
+      return response[0];
+    }
+
+    return {};
   }
 
   /**
@@ -250,7 +281,7 @@ export class CRUDOperations {
    * Truncate container (delete all rows)
    */
   async truncate(containerName: string): Promise<void> {
-    await this.executeSql(`DELETE FROM ${containerName}`);
+    await this.executeDml(`DELETE FROM ${containerName}`);
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,7 +57,7 @@ export interface GridDBRow {
 
 // Query types
 export interface GridDBQuery {
-  type: 'sql-select' | 'tql';
+  type: 'sql-select' | 'sql-update' | 'tql';
   stmt: string;
   bindings?: GridDBValue[];
 }

--- a/tests/operations/crud.test.ts
+++ b/tests/operations/crud.test.ts
@@ -290,8 +290,8 @@ describe('CRUDOperations', () => {
       );
     });
 
-    it('should update with where clause', async () => {
-      mockClient.post.mockResolvedValue([{ results: [[1]] }]);
+    it('should update with where clause using DML endpoint', async () => {
+      mockClient.post.mockResolvedValue([{ updatedRows: 1 }]);
 
       await crud.update({
         containerName: 'users',
@@ -301,10 +301,10 @@ describe('CRUDOperations', () => {
       });
 
       expect(mockClient.post).toHaveBeenCalledWith(
-        '/sql/dml/query',
+        '/sql/update',
         expect.arrayContaining([
           expect.objectContaining({
-            type: 'sql-select',
+            type: 'sql-update',
             stmt: expect.stringContaining('UPDATE users SET status = ? WHERE id = ?'),
             bindings: ['active', 1]
           })
@@ -314,8 +314,8 @@ describe('CRUDOperations', () => {
   });
 
   describe('delete', () => {
-    it('should delete with where clause', async () => {
-      mockClient.post.mockResolvedValue([{ results: [] }]);
+    it('should delete with where clause using DML endpoint', async () => {
+      mockClient.post.mockResolvedValue([{ updatedRows: 1 }]);
 
       await crud.delete({
         containerName: 'users',
@@ -324,15 +324,38 @@ describe('CRUDOperations', () => {
       });
 
       expect(mockClient.post).toHaveBeenCalledWith(
-        '/sql/dml/query',
+        '/sql/update',
         expect.arrayContaining([
           expect.objectContaining({
-            type: 'sql-select',
+            type: 'sql-update',
             stmt: 'DELETE FROM users WHERE id = ?',
             bindings: [1]
           })
         ])
       );
+    });
+
+    it('should delete without bindings', async () => {
+      mockClient.post.mockResolvedValue([{ updatedRows: 5 }]);
+
+      await crud.delete({
+        containerName: 'users',
+        where: 'status = \'inactive\''
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/sql/update',
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'sql-update',
+            stmt: 'DELETE FROM users WHERE status = \'inactive\''
+          })
+        ])
+      );
+
+      // Verify bindings is NOT included when not provided
+      const callArgs = mockClient.post.mock.calls[0][1][0];
+      expect(callArgs).not.toHaveProperty('bindings');
     });
   });
 
@@ -455,8 +478,8 @@ describe('CRUDOperations', () => {
 
     it('should update if exists', async () => {
       mockClient.post
-        .mockResolvedValueOnce([{ results: [[1]] }]) // count returns 1
-        .mockResolvedValueOnce({ success: true });
+        .mockResolvedValueOnce([{ results: [[1]] }]) // count returns 1 (via executeSql -> /sql/dml/query)
+        .mockResolvedValueOnce([{ updatedRows: 1 }]); // update (via executeDml -> /sql/update)
 
       await crud.upsert(
         'users',
@@ -465,22 +488,95 @@ describe('CRUDOperations', () => {
       );
 
       expect(mockClient.post).toHaveBeenCalledTimes(2);
+      // Second call should be to the DML update endpoint
+      expect(mockClient.post).toHaveBeenLastCalledWith(
+        '/sql/update',
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'sql-update',
+            stmt: expect.stringContaining('UPDATE users SET')
+          })
+        ])
+      );
     });
   });
 
   describe('truncate', () => {
-    it('should delete all rows from container', async () => {
-      mockClient.post.mockResolvedValue([{ results: [] }]);
+    it('should delete all rows using DML endpoint', async () => {
+      mockClient.post.mockResolvedValue([{ updatedRows: 100 }]);
 
       await crud.truncate('users');
 
       expect(mockClient.post).toHaveBeenCalledWith(
-        '/sql/dml/query',
+        '/sql/update',
         expect.arrayContaining([
           expect.objectContaining({
+            type: 'sql-update',
             stmt: 'DELETE FROM users'
           })
         ])
+      );
+    });
+  });
+
+  describe('executeDml', () => {
+    it('should use sql-update type and /sql/update endpoint', async () => {
+      mockClient.post.mockResolvedValue([{ updatedRows: 1 }]);
+
+      await crud.executeDml('DELETE FROM users WHERE id = 1');
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/sql/update',
+        [{ type: 'sql-update', stmt: 'DELETE FROM users WHERE id = 1' }]
+      );
+    });
+
+    it('should include bindings when provided', async () => {
+      mockClient.post.mockResolvedValue([{ updatedRows: 1 }]);
+
+      await crud.executeDml('DELETE FROM users WHERE id = ?', [1]);
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/sql/update',
+        [{ type: 'sql-update', stmt: 'DELETE FROM users WHERE id = ?', bindings: [1] }]
+      );
+    });
+
+    it('should omit bindings when not provided', async () => {
+      mockClient.post.mockResolvedValue([{ updatedRows: 0 }]);
+
+      await crud.executeDml('DELETE FROM users WHERE id = 999');
+
+      const callArgs = mockClient.post.mock.calls[0][1][0];
+      expect(callArgs).not.toHaveProperty('bindings');
+    });
+  });
+
+  describe('executeSql', () => {
+    it('should omit bindings when not provided', async () => {
+      mockClient.post.mockResolvedValue([{
+        columns: [{ name: 'count', type: 'LONG' }],
+        results: [[5]]
+      }]);
+
+      await crud.executeSql('SELECT COUNT(*) FROM users');
+
+      const callArgs = mockClient.post.mock.calls[0][1][0];
+      expect(callArgs).not.toHaveProperty('bindings');
+      expect(callArgs.type).toBe('sql-select');
+    });
+
+    it('should include bindings when provided', async () => {
+      mockClient.post.mockResolvedValue([{
+        columns: [{ name: 'id', type: 'INTEGER' }],
+        results: [[1]]
+      }]);
+
+      await crud.executeSql('SELECT * FROM users WHERE id = ?', [1]);
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/sql/dml/query',
+        [{ type: 'sql-select', stmt: 'SELECT * FROM users WHERE id = ?', bindings: [1] }]
       );
     });
   });


### PR DESCRIPTION
## Summary

- **`delete()`, `update()` (with WHERE), and `truncate()`** fail on GridDB Cloud because they use `executeSql()` which sends `type: 'sql-select'` to `/sql/dml/query` — but DML statements require `type: 'sql-update'` via the `/sql/update` endpoint
- **`bindings` field** is always included in the query payload even when `undefined`, causing GridDB Cloud to reject requests with `"Mapping JSON data error at object 1 field 'bindings'"`

## Changes

- Add new `executeDml()` method that uses `POST /sql/update` with `type: 'sql-update'` for DML operations
- Update `delete()`, `update()` (with WHERE clause), and `truncate()` to use `executeDml()` instead of `executeSql()`
- Strip `undefined`/empty `bindings` from both `executeSql()` and `executeDml()` query payloads
- Add `'sql-update'` to the `GridDBQuery.type` union type
- Expose `executeDml()` on the main `GridDB` class
- Update and add tests for all affected operations (175 tests pass)

## Context

Discovered while building a CRUD app on GridDB Cloud — `select()`, `selectOne()`, `count()`, `insert()` all work correctly, but `delete()` and `update()` with WHERE clauses fail because GridDB Cloud Web API strictly separates SELECT queries from DML statements at the endpoint level.

## Test plan

- [x] All 175 existing + new unit tests pass
- [x] Verified against live GridDB Cloud instance
- [x] `delete()` with WHERE clause works
- [x] `update()` with WHERE clause works  
- [x] `truncate()` works
- [x] `executeSql()` (SELECT) still works without bindings
- [x] `executeDml()` new method works for raw DML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DELETE/UPDATE/TRUNCATE on GridDB Cloud by sending DML to the correct `/sql/update` endpoint with `type: 'sql-update'`, and omits empty bindings to prevent API errors. Adds `executeDml()` and updates types/tests.

- **Bug Fixes**
  - Route `delete()`, `update()` with WHERE, and `truncate()` through `/sql/update` using `type: 'sql-update'`.
  - Omit undefined/empty `bindings` in both SELECT and DML payloads to avoid “Mapping JSON data error”.

- **New Features**
  - Added `executeDml(stmt, bindings?)` and exposed it on `GridDB`.
  - Extended `GridDBQuery.type` to include `'sql-update'`.
  - Updated tests to verify endpoint, query type, and bindings behavior.

<sup>Written for commit ac3c0109f9818ee6960179fe335417426744d010. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

