### PR TITLE
docs: update README for DML changes and GridDB Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,28 +221,35 @@ const user = await griddb.selectOne({
 #### Update
 
 ```typescript
-// Update by primary key
+// Update by primary key (upsert via rowkey — recommended)
 await griddb.update({
   containerName: 'users',
   data: { id: 1, name: 'Alice Updated', email: 'alice.new@example.com' }
 });
 
-// Update with conditions
+// Update with WHERE clause
 await griddb.update({
   containerName: 'users',
   data: { status: 'inactive' },
-  where: 'last_login < ?',
-  bindings: ['2023-01-01']
+  where: `last_login < '2023-01-01'`
 });
 ```
+
+> **Note:** When no `where` clause is provided, update uses the Row API (PUT) which upserts by rowkey. When a `where` clause is provided, it uses SQL UPDATE via the DML endpoint. For GridDB Cloud, prefer inline values in the WHERE clause over parameterized `bindings`.
 
 #### Delete
 
 ```typescript
+// Delete by ID
 await griddb.delete({
   containerName: 'users',
-  where: 'id = ?',
-  bindings: [1]
+  where: 'id = 1'
+});
+
+// Delete with condition
+await griddb.delete({
+  containerName: 'users',
+  where: `status = 'inactive'`
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ console.log(users);
 
 ## API Documentation
 
+### API Overview
+
+| Method | Description |
+|--------|-------------|
+| `createContainer(options)` | Create a new container |
+| `dropContainer(name)` | Drop a container |
+| `listContainers()` | List all containers |
+| `containerExists(name)` | Check if container exists |
+| `getSchema(name)` | Get container schema |
+| `insert(options)` | Insert one or more rows |
+| `batchInsert(name, data, batchSize)` | Batch insert with error handling |
+| `select(options)` | Query rows with conditions |
+| `selectOne(options)` | Query a single row |
+| `count(name, where?, bindings?)` | Count rows |
+| `exists(name, where, bindings?)` | Check if rows exist |
+| `update(options)` | Update rows (by rowkey or WHERE clause) |
+| `delete(options)` | Delete rows by condition |
+| `truncate(name)` | Delete all rows from container |
+| `upsert(name, data, uniqueColumns)` | Insert or update |
+| `executeSql(stmt, bindings?)` | Execute raw SELECT query |
+| `executeDml(stmt, bindings?)` | Execute raw DML (INSERT/UPDATE/DELETE) |
+| `executeTql(name, query)` | Execute TQL query |
+
 ### Initialization
 
 ```typescript
@@ -233,9 +256,18 @@ await griddb.upsert(
 );
 ```
 
+#### Truncate
+
+```typescript
+// Delete all rows from a container
+await griddb.truncate('users');
+```
+
 ### Query Execution
 
-#### SQL Queries
+#### SQL Queries (SELECT)
+
+Use `executeSql` for read-only SELECT queries. This sends `type: 'sql-select'` to the `/sql/dml/query` endpoint.
 
 ```typescript
 const result = await griddb.executeSql(
@@ -244,6 +276,27 @@ const result = await griddb.executeSql(
 );
 console.log(result.results);
 ```
+
+#### SQL DML Statements (INSERT, UPDATE, DELETE)
+
+Use `executeDml` for data modification statements. This sends `type: 'sql-update'` to the `/sql/update` endpoint, which is required by GridDB Cloud Web API for DML operations.
+
+```typescript
+// Delete with raw SQL
+const result = await griddb.executeDml(
+  'DELETE FROM users WHERE status = ?',
+  ['inactive']
+);
+console.log(result.updatedRows);
+
+// Update with raw SQL
+await griddb.executeDml(
+  'UPDATE users SET status = ? WHERE last_login < ?',
+  ['inactive', '2023-01-01']
+);
+```
+
+> **Note:** The high-level `delete()`, `update()`, and `truncate()` methods use `executeDml` internally. You only need `executeDml` directly for complex DML statements not covered by the convenience methods.
 
 #### TQL Queries
 
@@ -368,6 +421,7 @@ import {
   GridDBConfig,
   GridDBColumn,
   GridDBRow,
+  GridDBQuery,
   ContainerType,
   GridDBColumnType,
   CreateOptions,
@@ -378,6 +432,43 @@ import {
   QueryResult,
   BatchOperationResult
 } from '@junwatu/griddb-client';
+```
+
+### GridDBQuery Type
+
+```typescript
+interface GridDBQuery {
+  type: 'sql-select' | 'sql-update' | 'tql';
+  stmt: string;
+  bindings?: GridDBValue[];
+}
+```
+
+- `sql-select` — Used for SELECT queries via `/sql/dml/query`
+- `sql-update` — Used for DML statements (INSERT, UPDATE, DELETE) via `/sql/update`
+- `tql` — Used for TQL queries
+
+## GridDB Cloud
+
+This library fully supports [GridDB Cloud](https://cloud.griddb.com). GridDB Cloud's Web API strictly separates SELECT queries from DML (data modification) operations at the endpoint level:
+
+| Operation | API Type | Endpoint |
+|-----------|----------|----------|
+| SELECT, COUNT | `sql-select` | `/sql/dml/query` |
+| INSERT, UPDATE, DELETE | `sql-update` | `/sql/update` |
+
+The library handles this automatically — `select()`, `selectOne()`, `count()` use the SELECT endpoint, while `delete()`, `update()` (with WHERE clause), and `truncate()` use the DML endpoint.
+
+> **Tip:** Make sure your IP address is added to the GridDB Cloud allowlist, otherwise all requests will return `403 Forbidden`.
+
+### GridDB Cloud Configuration
+
+```typescript
+const griddb = new GridDB({
+  griddbWebApiUrl: 'https://cloud1.griddb.com/trial1234/griddb/v2/gs_clustertrial1234/dbs/public',
+  username: 'your_username',
+  password: 'your_password'
+});
 ```
 
 ## Environment Variables


### PR DESCRIPTION
## Summary

Follow-up to PR #3 (merged). Updates the README to document the new `executeDml()` method and GridDB Cloud specifics.

## Changes

- Add **API Overview** table listing all 18 available methods
- Document **`executeDml()`** with usage examples for raw DML statements
- Document **`truncate()`** method (was previously undocumented)
- Add **GridDB Cloud** section explaining endpoint separation (`sql-select` vs `sql-update`) with config example and IP allowlist tip
- Add **`GridDBQuery` type** documentation showing all query types
- Fix **`delete()` and `update()` examples** to use inline WHERE values instead of parameterized `bindings` (which GridDB Cloud rejects)

## Test plan

- [x] README only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README to document the new `executeDml()` method and GridDB Cloud usage, including endpoint separation (`sql-select` vs `sql-update`) and a configuration example. Adds an API overview table, documents `truncate()` and the `GridDBQuery` type, and fixes `update()`/`delete()` examples to use inline WHERE values for Cloud compatibility.

<sup>Written for commit 229e1c3021c225fada283451505d1b852fce75ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

